### PR TITLE
Fix the "copy" for Noc 1h Actin

### DIFF
--- a/experimentA/rendering_settings/idr0050-all-renderingMapping.tsv
+++ b/experimentA/rendering_settings/idr0050-all-renderingMapping.tsv
@@ -5,7 +5,7 @@ DMSO 30min Actin	DMSO 30min Actin.yml
 DMSO 5min Actin	DMSO 5min Actin.yml
 DMSO Control Actin	DMSO Control Actin.yml
 Noc 10min Actin	Noc 10min Actin.yml
-Noc 1h Actin copy	Noc 1h Actin copy.yml
+Noc 1h Actin	Noc 1h Actin.yml
 Noc 20min Actin	Noc 20min Actin.yml
 Noc 30min Actin	Noc 30min Actin.yml
 Noc 5min Actin	Noc 5min Actin.yml


### PR DESCRIPTION
Omission in the rendering mappings tsv file.

cc @francesw @sbesson 