### PR TITLE
Final rendering adjustments

### DIFF
--- a/experimentA/rendering_settings/ExperimentB_No05_DMSO_11_10min.yml
+++ b/experimentA/rendering_settings/ExperimentB_No05_DMSO_11_10min.yml
@@ -17,4 +17,4 @@ channels:
     label: Microtubules
     start: 0
 version: 2
-z: 5
+z: 1

--- a/experimentA/rendering_settings/idr0050-images-renderingMapping.tsv
+++ b/experimentA/rendering_settings/idr0050-images-renderingMapping.tsv
@@ -10,8 +10,8 @@ ExperimentB_No10_DMSO_21_1h
 ExperimentB_No11_Noc_18_1h
 ExperimentB_No12_Noc_19_1h
 ExperimentB_No14_DMSO_08_1h
-ExperimentB_No15_Noc_04_1h.yml
-ExperimentB_No16_Noc_06_1h.yml
+ExperimentB_No15_Noc_04_1h
+ExperimentB_No16_Noc_06_1h
 ExperimentB_No18_DMSO_C2_20min
 ExperimentB_No20_Noc_23_20min
 ExperimentB_No21_DMSO_16_30min


### PR DESCRIPTION
- updates the Z plane of the first dataset to use `z: 1`. After review with @francesw, this ended up being the best compromise between having a single Z plane per batch and having as few black thumbnails as possible
- removes unexpected trailing `.yml` from `ExperimentB_No15` and `ExperimentB_No16` . This prevented the rendering to be applied to the images as the query returned no images